### PR TITLE
Fix a typo in Cairo page + Remove coach

### DIFF
--- a/cairo.html
+++ b/cairo.html
@@ -291,11 +291,6 @@ Steps to show on site
             <small>@blaz_boy</small>
         </a>
 
-        <a href="https://twitter.com/amrsobhy" class="grid_3">
-            Amr Sobhy,<br/> coach 
-            <small>@amrsobhy</small>
-        </a>
-
         <a href="https://twitter.com/seifsallam" class="grid_3">
             Seif Sallam,<br/> coach 
             <small>@seifsallam</small>


### PR DESCRIPTION
Fixed a typo. Also, a coach apologized for not being able to attend on the specified dates so I removed him.
