### PR TITLE
Fix Braga 2014 link from the Events page

### DIFF
--- a/events.html
+++ b/events.html
@@ -729,7 +729,7 @@
       </div>
     </a>
 
-    <a href="./rg-braga2014.html" class="event" style="background:url(images/braga/braga2014/ruby-braga.png) 0px 0px no-repeat;">
+    <a href="./braga2014.html" class="event" style="background:url(images/braga/braga2014/ruby-braga.png) 0px 0px no-repeat;">
       <div>
         <h3>Braga, Portugal</h3>
         <p>12 October 2014</p>


### PR DESCRIPTION
I was clicking around Portugal events and the link to RGBraga 2014 on the Events page is wrong. This fixes it. :)
