### PR TITLE
Events/novohamburgo adjustments

### DIFF
--- a/novohamburgo.html
+++ b/novohamburgo.html
@@ -206,7 +206,7 @@
           <h2>Sábado, 21 de Maio</h2>
           <div class="grid_5">
             <span class="time">08:30</span>
-            <h4>Café da manhã</h4>
+            <h4>Café da manhã e credenciamento</h4>
           </div>
           <div class="grid_5">
             <span class="time">09:00</span>


### PR DESCRIPTION
Some minor adjustments for Novo Hamburgo event page:
- Correct the event address (was missing the room number)
- Reorder team members by first name
- Set Novo Hamburgo image as `og:image` (for facebook sharing)
- Add _registration_ alongside Saturday breakfast
