### PR TITLE
Show correct header image in Tokyo #5 event page

### DIFF
--- a/tokyo-2015-09-12.html
+++ b/tokyo-2015-09-12.html
@@ -77,7 +77,7 @@ Steps to show on site
 
     <div id="container" class="container_12 page clearfix">
       <div class="grid_12 omega alpha">
-        <div id="promo" class="new tokyo">
+        <div id="promo" class="new tokyo-2015-09-12">
           <h1>Rails Girls Tokyo
               <small>12 September 2015</small>
           </h1>


### PR DESCRIPTION
I didn't update the css class of previous event page...
