### PR TITLE
Next RG Kyoto happens at the next day of RubyKaigi 2016

### DIFF
--- a/kyoto201609.html
+++ b/kyoto201609.html
@@ -115,7 +115,7 @@ Steps to show on site
             <div>
 
               <div style="margin:0 15px 0 0;">
-                <a href="http://twitter.com/share" class="twitter-share-button" data-url="" data-text="Rails Girls Kyoto 14-15th December - apply now!" data-count="horizontal" data-via="railsgirls" data-related="railsgirls">
+                <a href="http://twitter.com/share" class="twitter-share-button" data-url="" data-text="Rails Girls Kyoto 11th September - apply now!" data-count="horizontal" data-via="railsgirls" data-related="railsgirls">
           Tweet</a>
                 <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
               </div>


### PR DESCRIPTION
data-text  here points at wrong dates, and so this produces a misleading tweet like this: https://twitter.com/yotii23/status/765817616522813440
@springaki 
