### PR TITLE
Fix description of Rotterdam page

### DIFF
--- a/rotterdam19.html
+++ b/rotterdam19.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 
     <title>Rotterdam June 20, 2019</title>
-    <meta name="description" content="Rails Girls goes Rotterdam on 14 April 2018: join the two-day crash course to the exciting world of building web applications with Ruby on Rails.">
+    <meta name="description" content="Rails Girls goes Rotterdam on June 20, 2019: join the two-day crash course to the exciting world of building web applications with Ruby on Rails.">
     <meta name="author" content="Rails Girls">
 
     <link rel="shortcut icon" href="/favicon.png">


### PR DESCRIPTION
Hey hey, just noticed that the `<meta description>` still mentions 14 April 2018 so I took the liberty to update the timestamp there as well :)