### PR TITLE
fix events/events.json syntax error.

### DIFF
--- a/events/events.json
+++ b/events/events.json
@@ -14,7 +14,7 @@
     "endDate": "2019-04-13",
     "imageUrl": "/images/railsgirls-sq.png",
     "eventUrl": "/skopje.html"
-  }
+  },
   {
     "location": "Tokyo, Japan",
     "writtenDate": "February 22nd & 23rd, 2019",


### PR DESCRIPTION
No events shows in `Upcoming Evnets` on top page because of events.json syntax error.
I fix it.