### PR TITLE
inyourcity page modified to embed SSL form

### DIFF
--- a/inyourcity.html
+++ b/inyourcity.html
@@ -63,7 +63,9 @@
     'formHash':'q7x3q7', 
     'autoResize':true,
     'width': '600',
-    'header':'show'});
+    'header':'show',
+    'ssl':true,
+    });
     q7x3q7.display();
     </script>
     </p>


### PR DESCRIPTION
I received a notification that the form could not be displayed on the [inyourcity](https://railsgirls.com/inyourcity) page, so I made a modification to make it appear.
The reason was that the script was trying to embed URL on http (not https), then browsers bloked.
So I made a correction to load it SSL.

I am sorry that I was unable to get confirmation of the behavior locally, but I have confirmed that the URL of the form to embed has changed to one that uses SSL as a result of this modification.