### PR TITLE
X(旧Twitter)でOGPが表示されない問題を修正

### DIFF
--- a/tokyo.html
+++ b/tokyo.html
@@ -43,6 +43,8 @@
       } catch (e) {}
     </script>
 
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:site" content="@railsgirls" />
     <meta property="og:url" content="https://railsgirls.com/tokyo" />
     <meta property="og:image" content="https://railsgirls.com/images/tokyo/rails_girls_tokyo_16th_OGP.png" />
     <!--[if lt IE 9]>


### PR DESCRIPTION
## やったこと
X(旧Twitter)でイベントページのURLをシェアする際にOGPが表示されないため、 X用のmetaタグを追加した

<img width="575" alt="Monosnap ホーム : X 2024-01-03 20-47-40" src="https://github.com/railsgirls/railsgirls.com/assets/76797372/8ddcfeb6-0445-4831-932b-2e5a6cd7bd37">
<img width="1068" alt="Monosnap Card Validator | Twitter Developers 2024-01-03 20-48-37" src="https://github.com/railsgirls/railsgirls.com/assets/76797372/01f4b9f3-71c2-4fe4-9f65-16a9346e147d">

## エビデンス
https://developer.twitter.com/ja/docs/tweets/optimize-with-cards/guides/getting-started 
X開発者プラットフォームのカードの利用開始の説明に従って、metaタグを追加した

https://railsgirls.com/fukuoka-2020.html
2020年開催のFukuokaは上記プラットフォームで指定されているmetaタグが設定されているため、Xでシェアする際にOGPが表示されていた。
<img width="589" alt="Monosnap ホーム : X 2024-01-03 20-45-51" src="https://github.com/railsgirls/railsgirls.com/assets/76797372/bce87ffe-fe05-4705-8f19-ec67a061f48f">

<img width="1073" alt="Monosnap Card Validator | Twitter Developers 2024-01-03 20-46-46" src="https://github.com/railsgirls/railsgirls.com/assets/76797372/3d710d70-0010-4925-9ed4-36b0e28b28af">
