### PR TITLE
株式会社SmartHR様のホームページのURLが誤っていたため修正した

### DIFF
--- a/tokyo.html
+++ b/tokyo.html
@@ -361,8 +361,8 @@
           </p>
 
           <p>
-            <a href="https://smarthr.jp/" style="float:right; margin:0 0 0 15px; border:0; "><img src="images/japan/SmartHR_Logo.png" alt="株式会社SmartHR" width="200"></a>
-            <a href="https://smarthr.jp/">株式会社SmartHR</a>
+            <a href="https://smarthr.co.jp/" style="float:right; margin:0 0 0 15px; border:0; "><img src="images/japan/SmartHR_Logo.png" alt="株式会社SmartHR" width="200"></a>
+            <a href="https://smarthr.co.jp/">株式会社SmartHR</a>
             は、「well-working 労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会をつくる。」をミッションに、クラウド人事労務ソフト「SmartHR」を開発・運営しています。雇用契約、年末調整などの人事・労務業務の効率化を支援する機能や、人事評価、配置シミュレーションなどのタレントマネジメント機能を提供しています。
           </p>
 


### PR DESCRIPTION
## やったこと
株式会社SmartHR様のホームページのURLが昨年と異なることに気が付かずサイトに反映をしてしまったため、正しいURLに修正しました。

誤）https://smarthr.jp/
↓
正）https://smarthr.co.jp/
