### PR TITLE
Coach and staff information added to Rails Girls Tokyo 16th site

### DIFF
--- a/tokyo.html
+++ b/tokyo.html
@@ -407,35 +407,19 @@
             Mayumi Emori<br />Organizer, Coach<small>@emorima</small>
           </a>
 
-         <a href="https://github.com/moegi29" class="grid_3">
-            <img src="https://avatars.githubusercontent.com/u/111144394?v=4" class="coach" />
-            moegi<br />Staff, Logo Design<small>@moegi29</small>
-          </a>
-
-           <!--
-          <a href="https://github.com/okuramasafumi" class="grid_3">
-            <img src="https://avatars.githubusercontent.com/u/1012014?v=4" class="coach" />
-            OKURA Masafumi<br />Coach<small>@okuramasafumi</small>
-          </a>
-
-          <a href="https://github.com/risacan" class="grid_3">
-            <img src="https://avatars.githubusercontent.com/u/13192318?v=4" class="coach" />
-            Risa<br />Coach<small>@risacan</small>
-          </a>
-
-          <a href="https://twitter.com/krpk1900_dev" class="grid_3">
-            <img src="https://pbs.twimg.com/profile_images/1355162904266326016/XczLBvZi.jpg" class="coach" />
-            Shogo Terai<br />Coach<small>@krpk1900_dev</small>
-          </a>
+          <a href="https://github.com/moegi29" class="grid_3">
+              <img src="https://avatars.githubusercontent.com/u/111144394?v=4" class="coach" />
+              moegi<br />Staff, Logo Design<small>@moegi29</small>
+            </a>
 
           <a href="https://twitter.com/cafedomancer" class="grid_3">
             <img src="https://pbs.twimg.com/profile_images/1555769692404727808/RZWPZvdo.jpg" class="coach" />
             Shohei Umemoto<br />Coach<small>@cafedomancer</small>
           </a>
 
-          <a href="" class="grid_3">
-            <img src="https://avatars.githubusercontent.com/u/29417697?v=4" class="coach" />
-            ONOE AZUSA<br />Coach<small></small>
+          <a href="https://twitter.com/suuuuengch" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1344858357429981185/gRMDI8s8_400x400.jpg" class="coach" />
+            eririn<br />Coach<small>@suuuuengch</small>
           </a>
 
           <a href="https://twitter.com/chobishiba" class="grid_3">
@@ -443,19 +427,14 @@
             Miyuki Koshiba<br />Coach<small>@chobishiba</small>
           </a>
 
-          <a href="https://twitter.com/16bit_idol" class="grid_3">
-            <img src="https://pbs.twimg.com/profile_images/451154800424407040/qRR19sgd.jpeg" class="coach" />
-            16bit_idol<br />Coach<small>@16bit_idol</small>
+          <a href="https://twitter.com/yuki3738" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1183764422214344704/c12J8iXX_400x400.jpg" class="coach" />
+            Yuki MINAMIYA<br />Coach<small>@yuki3738</small>
           </a>
 
-          <a href="https://twitter.com/UsaMomokawa" class="grid_3">
-            <img src="https://pbs.twimg.com/profile_images/1007403486034587648/A5F2d7Q3.jpg" class="coach" />
-            momokawa<br />Coach<small>@UsaMomokawa</small>
-          </a>
-
-          <a href="https://twitter.com/shiori_peace" class="grid_3">
-            <img src="https://pbs.twimg.com/profile_images/907908141198729216/WmkfMSvC.jpg" class="coach" />
-            Shiorin<br />Coach<small>@shiori_peace</small>
+          <a href="https://twitter.com/krpk1900_dev" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1355162904266326016/XczLBvZi.jpg" class="coach" />
+            Shogo Terai<br />Coach<small>@krpk1900_dev</small>
           </a>
 
           <a href="https://twitter.com/beta_chelsea" class="grid_3">
@@ -463,9 +442,14 @@
             beta_chelsea<br />Coach<small>@beta_chelsea</small>
           </a>
 
-          <a href="https://twitter.com/nobu09_" class="grid_3">
-            <img src="https://pbs.twimg.com/profile_images/1205729379327696896/0uBcHxH-.jpg" class="coach" />
-            nobu09<br />Coach<small>@nobu09</small>
+          <a href="https://github.com/neko314" class="grid_3">
+            <img src="https://avatars.githubusercontent.com/u/29836309?v=4" class="coach" />
+            Keiko Kaneko<br />Coach<small>@neko314</small>
+          </a>
+
+          <a href="https://github.com/rotelstift" class="grid_3">
+            <img src="https://avatars.githubusercontent.com/u/10988907?v=4" class="coach" />
+            rotelstift<br />Coach<small>@rotelstift</small>
           </a>
 
           <a href="https://github.com/shimoju" class="grid_3">
@@ -473,31 +457,70 @@
             Hiroshi Shimoju<br />Coach<small>@shimoju</small>
           </a>
 
-          <a href="https://github.com/ayaka-ramens" class="grid_3">
-            <img src="https://avatars.githubusercontent.com/u/52645663?v=4" class="coach" />
-            Ayaka Moronaga<br />Coach<small>@ayaka-ramens</small>
+          <a href="https://twitter.com/masaya_dev" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1597058239560318977/SXbarhYo_400x400.jpg" class="coach" />
+            msykd<br />Coach<small>@masaya_dev</small>
           </a>
 
-          <a href="https://github.com/fujimura" class="grid_3">
-            <img src="https://avatars.githubusercontent.com/u/134072?v=4" class="coach" />
-            fujimura<br />Coach<small>@fujimura</small>
+          <a href="https://twitter.com/yotii23" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1022311582569619456/etqSQx6X_400x400.jpg" class="coach" />
+            Yuki Torii<br />Coach<small>@yotii23</small>
           </a>
 
-          <a href="https://twitter.com/murokaco" class="grid_3">
-            <img src="https://secure.gravatar.com/avatar/cafcfbcd1d0b548895ff059bd0923a19" class="coach" />
-            murokaco<br />Staff, Logo Design<small>@murokaco</small>
+          <a href="https://twitter.com/haruna_tsujita" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1436695341013745664/MGYBFep3_400x400.jpg" class="coach" />
+            Haruna Tsujita<br />Coach<small>@haruna_tsujita</small>
           </a>
 
-          <a href="https://twitter.com/meguhaaan" class="grid_3">
-            <img src="https://pbs.twimg.com/profile_images/1503514785882664962/r85JnXef.jpg" class="coach" />
-            meguhan<br />Staff<small>@meguhan</small>
+          <a href="https://twitter.com/spinute" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1719026446625378304/srVk35sC_400x400.jpg" class="coach" />
+            Pin<br />Coach<small>@spinute</small>
           </a>
 
-          <a href="https://twitter.com/sai_fan_3" class="grid_3">
-            <img src="https://pbs.twimg.com/profile_images/1356915277020057600/z9CTqghN.jpg" class="coach" />
-            naa<br />Staff<small>@sai_fan_3</small>
-          </a> -->
+          <a href="https://twitter.com/tsummichan" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1512644646450925579/3HU3e-ju_400x400.jpg" class="coach" />
+            tsumichan<br />Coach<small>@tsumichan</small>
+          </a>
 
+          <a href="https://twitter.com/16bit_idol" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/451154800424407040/qRR19sgd.jpeg" class="coach" />
+            16bit_idol<br />Coach<small>@16bit_idol</small>
+          </a>
+
+          <a href="https://github.com/risacan" class="grid_3">
+            <img src="https://avatars.githubusercontent.com/u/13192318?v=4" class="coach" />
+            Risa<br />Coach<small>@risacan</small>
+          </a>
+
+          <a href="https://twitter.com/HolyGrail" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1746837505343991808/2aOs7MB6_400x400.jpg" class="coach" />
+            HolyGrail<br />Coach<small>@HolyGrail</small>
+          </a>
+
+          <a href="https://github.com/hogelog" class="grid_3">
+            <img src="https://avatars.githubusercontent.com/u/50920?v=4" class="coach" />
+            hogelog<br />Coach<small>@hogelog</small>
+          </a>
+
+          <a href="https://github.com/riseshia" class="grid_3">
+            <img src="https://avatars.githubusercontent.com/u/7338443?v=4" class="coach" />
+            Shia<br />Coach<small>@riseshia</small>
+          </a>
+
+          <a href="https://twitter.com/zanakax" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1605591531288932353/bUNgWNk5_400x400.jpg" class="coach" />
+            zanaka<br />Coach<small>@zanaka</small>
+          </a>
+
+          <a href="https://twitter.com/suzuka_hori" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1642660549279506432/3cq-uX7J_400x400.jpg" class="coach" />
+            すずか<br />Staff<small>@suzuka_hori</small>
+          </a>
+
+          <a href="https://twitter.com/motohiromm" class="grid_3">
+            <img src="https://pbs.twimg.com/profile_images/1725333033375731712/_oLtJ3Xq_400x400.jpg" class="coach" />
+            motohiro<br />Staff<small>@motohiromm</small>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## TODO
Coaches and staff have been confirmed and the information has been reflected in the Rails Girls Tokyo 16th Tokyo Team section.

<img width="674" alt="Monosnap Tokyo, 1st   2nd March 2024 2024-02-16 21-01-53" src="https://github.com/railsgirls/railsgirls.com/assets/76797372/ab89ae86-8ccd-4ff0-9dcb-9d6b98f1d266">
