### PR TITLE
Rails Girls Nagoya 6thイベントページにDoorkeeperへの導線を追加

### DIFF
--- a/nagoya.html
+++ b/nagoya.html
@@ -79,13 +79,14 @@ Steps to show on site
           1日のワークショップで、Ruby on Rails の素敵な世界を体験してみませんか？ワークショップは無料です。<br>
           </p>
           <p>
-           <strong> 準備中です...
-            </strong>
+            応募を開始しました！！！<br>
+            3/17(日)までに
+            <a href="https://railsgirls-nagoya.doorkeeper.jp/events/170443" target="_blank"><strong>Doorkeeperの募集ページ</strong></a> からお申し込みください！<br>
           </p>
 
           <p> Hello world!<br>
           Rails Girls comes to Nagoya again! During the free two-day workshop we'll dive into the magical world of Ruby on Rails!</p>
-           <p><strong>Application will be open on March 4.</strong></p>
+           <p>Please apply from <a href="https://railsgirls-nagoya.doorkeeper.jp/events/170443" target="_blank"><strong>Event page</strong></a>！</p>
           <!--  Update the sharing texts.-->
 
           <div id="share">
@@ -153,7 +154,7 @@ Steps to show on site
                   <h4>ライトニングトークス</h4>
                 </td>
               </tr>
-              
+
               <tr>
                 <th>14:30 - 17:00</th>
                 <td>
@@ -194,7 +195,7 @@ Steps to show on site
           </strong></p>
           わたしたちは RailsGirls イベントとコミュニティの安全、生産的なコラボレーションのために 上記のガイドラインを選びました。
 
-    
+
           <!-- Feel free to group the sponsors as you wish. E.g media, friends, premium sponsors etc. You know best the situation in your city! Pictures should be either 100 x 100px or 250 x 90px -->
           <hr />
           <h3>パートナー</h3>


### PR DESCRIPTION

Rails Girls Nagoya 6th の募集が開始されているため、#2218 で作成したイベントページへ、[Doorkeeperイベントページ](https://railsgirls-nagoya.doorkeeper.jp/events/170443)への導線を追加