### PR TITLE
fix Melbourne's date format on events.json

### DIFF
--- a/events/events.json
+++ b/events/events.json
@@ -59,8 +59,8 @@
     {
       "location": "Melbourne, Australia",
       "writtenDate": "July 20th, 2024",
-      "startDate": "2024-20-07",
-      "endDate": "2024-20-07",
+      "startDate": "2024-07-20",
+      "endDate": "2024-07-20",
       "imageUrl": "/images/railsgirls-sq.png",
       "eventUrl": "/melbourne.html"
     },


### PR DESCRIPTION
The date format was incorrect as YYYY-DD-MM,
so Events in Melbourne that have ended were displayed under Upcoming Events on the top page.