### PR TITLE
add default Logo on Nagasaki 2nd page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1150,6 +1150,12 @@ url('../images/separator.png') no-repeat center bottom;
                   url('../images/separator.png') no-repeat center bottom;
   background-size: 390px;
 }
+.nagasaki-2nd#promo {
+  padding-left: 420px;
+  background: url('../images/railsgirls-sq.png') no-repeat left top;
+                  url('../images/separator.png') no-repeat center bottom;
+  background-size: 390px;
+}
 
 .chicago#promo {
   padding-left:340px;


### PR DESCRIPTION
add default Logo on Nagasaki 2nd page.

## before
![image](https://github.com/user-attachments/assets/e4cbb824-9a87-428d-89d3-ff732b69ac8e)

## after

![image](https://github.com/user-attachments/assets/ab6f81d7-61ec-484d-901b-562a88ee8088)
