### PR TITLE
Attached mobile-compatible styles to sapporo 2nd

### DIFF
--- a/css/japan.css
+++ b/css/japan.css
@@ -44,7 +44,7 @@ h3, h4, h5, a {
 }
 
 p {
-    margin: 0 auto var(--24px) auto;
+    margin: 0 0 var(--24px) 0;
 }
 
 nav, footer {

--- a/sapporo-2nd.html
+++ b/sapporo-2nd.html
@@ -7,37 +7,21 @@
     <title>Sapporo, 17th & 18th October 2025</title>
     <!--  Write a metatext. This is what will show on the Facebook page and for instance search engines. -->
 
-    <meta
-      name="description"
-      content="Rails Girls goes Sapporo, 17 & 18 October 2025: join the two-day crash-course to the exciting world of building web applications with Ruby on Rails."
-    />
+    <meta name="viewport" content="width=device-width">
+    <meta name="description" content="Rails Girls goes Sapporo, 17 & 18 October 2025: join the two-day crash-course to the exciting world of building web applications with Ruby on Rails.">
     <meta name="author" content="Rails Girls" />
     <link rel="shortcut icon" href="./images/favicon.png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 
     <link rel="stylesheet" href="./css/style.css" />
-    <style>
-      .coach {
-        border-radius: 50px;
-      }
-      .list-black > li {
-        color: black;
-      }
-      .sapporo-2nd#promo {
-        background: url(./images/railsgirls-sq.png) 0px 80px / 35% no-repeat;
-        padding-left: 400px;
-      }
-    </style>
+    <link rel="stylesheet" href="./css/japan.css">
+    <link rel="stylesheet" href="./css/jp-responsive.css">
 
-    <script
-      type="text/javascript"
-      src="https://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js"
-    ></script>
-    <script type="text/javascript" src="main.js"></script>
-    <script
-      type="text/javascript"
-      src="https://apis.google.com/js/plusone.js"
-    ></script>
+    <script type="text/javascript" src="./assets/js/jp-responsive.js"></script>
+
+    <link rel="stylesheet" href="http://use.typekit.net/c/40007d/1w;expressway,2,NGc:F:i4,NGp:F:i7,N2r:F:n4,NGl:F:n6,NGn:F:n7/d?3bb2a6e53c9684ffdc9a9bf4185b2a627d237ba59c3d5cc9b5ca399d4ed47062bf0126571ca50ab6a338fba2a5f5d00c1e707fc7babc384ad6a0c38afab55f0eec246f6e8865cae9a7de5b7f99b6e6416be44691be6c64e8185a40b588748e875349df9f242c84f72c241e27aac6fc5e1b1c52889002ee483c56">
+    <script type="text/javascript" src="//use.typekit.net/nbs6fzt.js"></script>
+    <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@railsgirls" />
@@ -60,11 +44,28 @@
   </head>
   <body>
     <header>
-      <div class="container_12">
-        <a id="logo" href="/"
-          ><img src="images/railsgirls-logo.png" alt="Rails Girls"
-        /></a>
+      <div class="container_12" id="nav-for-pc">
+        <a id="logo" href="/"><img src="images/railsgirls-logo.png" alt="Rails Girls" /></a>
         <nav>
+          <a href="./events.html">Events</a>
+          <a href="./materials.html">Materials</a>
+          <a href="./press.html">Press</a>
+          <a href="https://railsgirls.tumblr.com/">Blog</a>
+          <a href="https://guides.railsgirls.com">Guides</a>
+        </nav>
+      </div>
+      <div class="container_12" id="nav-for-mobile">
+        <a id="logo-mobile" href="/"><img src="images/railsgirls-logo.png" alt="Rails Girls" /></a>
+
+        <div id="toggle-nav-header">
+          <button id="toggle-nav-btn">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+        </div>
+
+        <nav id="toggle-nav">
           <a href="./events.html">Events</a>
           <a href="./materials.html">Materials</a>
           <a href="./press.html">Press</a>
@@ -97,87 +98,89 @@
 
     <!--  Change the header text. You can include a local hello or something else that brings context. Remember to mention the workshop is free. Remember to change to wufoo form link and dates. -->
 
-    <div id="container" class="container_12 page clearfix">
-      <div class="grid_12 omega alpha">
-        <div id="promo" class="new sapporo-2nd">
-          <h1>
-            Rails Girls Sapporo
-            <small>17th & 18th October 2025</small>
-          </h1>
-          <p>こんにちは世界！</p>
-          <!-- TODO：ここの文言を考える。今は仮でIzumoの文章をまねてる -->
-          <p>
-            札幌で12年ぶり、2度目のRails Girlsが開催されます！<br />
-            Ruby on Rails のすてきな世界を私達と一緒に体験しましょう！<br />
-            無料のワークショップですので、お気軽にご参加ください。
-          </p>
+    <div id="container" class="container_12 page">
+      <div class="grid_12">
+        <div id="promo" class="grid_12">
+          <div class="event-logo">
+            <img src="images/railsgirls-sq.png">
+          </div>
+          <div class="overview">
+            <h1>
+              Rails Girls Sapporo
+              <small>17th & 18th October 2025</small>
+            </h1>
+            <p>こんにちは世界！</p>
+            <!-- TODO：ここの文言を考える。今は仮でIzumoの文章をまねてる -->
+            <p>
+              札幌で12年ぶり、2度目のRails Girlsが開催されます！<br />
+              Ruby on Rails のすてきな世界を私達と一緒に体験しましょう！<br />
+              無料のワークショップですので、お気軽にご参加ください。
+            </p>
 
-          <p>
-            応募開始前です。<br />
-            募集については2025年7月中を予定しています。<br />
-          </p>
-          <!-- <p>
-             <strong>
-              応募を開始しました！！！<br /> -->
-          <!-- TODO:応募の期日を決めて入力する -->
-          <!-- /()までに<a href="" target="_blank">こちら</a
-              >からご応募ください。<br />
-              応募が多い場合は抽選となります。ご了承ください。
-            </strong>
-          </p>-->
+            <p>
+              応募開始前です。<br />
+              募集については2025年7月中を予定しています。<br />
+            </p>
+            <!-- <p>
+              <strong>
+                応募を開始しました！！！<br /> -->
+            <!-- TODO:応募の期日を決めて入力する -->
+            <!-- /()までに<a href="" target="_blank">こちら</a
+                >からご応募ください。<br />
+                応募が多い場合は抽選となります。ご了承ください。
+              </strong>
+            </p>-->
 
-          <!-- <p><strong>参加者の募集は終了いたしました。ご応募ありがとうございました！</strong></p> -->
-          <br />
-
-          <div id="share">
-            <div>
-              <div style="margin: 0 15px 0 0">
-                <a
-                  href="https://x.com/share"
-                  class="twitter-share-button"
-                  data-url=""
-                  data-text="Rails Girls Sapporo, 17th & 18th October 2025 - お待ちしています!"
-                  data-count="horizontal"
-                  data-via="railsgirls"
-                  data-related="railsgirls"
-                  >Tweet</a
-                >
-                <script
-                  type="text/javascript"
-                  src="http://platform.twitter.com/widgets.js"
-                ></script>
+            <!-- <p><strong>参加者の募集は終了いたしました。ご応募ありがとうございました！</strong></p> -->
+            <div id="share">
+              <div>
+                <div style="margin: 0 15px 0 0">
+                  <a
+                    href="https://x.com/share"
+                    class="twitter-share-button"
+                    data-url=""
+                    data-text="Rails Girls Sapporo, 17th & 18th October 2025 - お待ちしています!"
+                    data-count="horizontal"
+                    data-via="railsgirls"
+                    data-related="railsgirls"
+                    >Tweet</a
+                  >
+                  <script
+                    type="text/javascript"
+                    src="http://platform.twitter.com/widgets.js"
+                  ></script>
+                </div>
               </div>
             </div>
+          </div>
+        </div>
+
+        <div class="grid_12">
+          <div class="grid_4 feature">
             <p>
-              <!-- margin workaround -->
+              <strong>概要</strong><br>
+              コーチに教えてもらいながらプログラムを設計して、プロトタイプを作り、コーディングします。
+            </p>
+          </div>
+          <div class="grid_4 feature">
+            <p>
+              <strong>必要なもの</strong><br>
+              ・ノートパソコン<br>
+              ・楽しみたい気持ちとほんのちょっとの好奇心<br>
+              </ul>
+            </p>
+          </div>
+          <div class="grid_4 feature">
+            <p>
+              <strong>不要なもの</strong><br>
+              ・プログラミングの知識や経験<br>
+              ・「私が参加して良いだろうか」という遠慮<br>
+              ・プログラミングって難しそう・・・という先入観<br>
             </p>
           </div>
         </div>
 
-        <!--  You can use here your own contact e-mail, or we can send you the e-mails from contact@! -->
-
-        <div class="grid_4 alpha feature">
-          <p>
-            <strong>概要</strong
-            ><br />コーチに教えてもらいながらプログラムを設計して、プロトタイプを作り、コーディングします。
-          </p>
-        </div>
-        <div class="grid_4 feature">
-          <p>
-            <strong>必要なもの</strong>
-            <br />・ノートパソコン
-            <br />・楽しみたい気持ちとほんのちょっとの好奇心
-          </p>
-        </div>
-        <div class="grid_4 omega feature">
-          <p>
-            <strong>不要なもの</strong>
-            <br />・プログラミングの知識や経験
-            <br />・「私が参加して良いだろうか」という遠慮
-            <br />・プログラミングって難しそう・・・という先入観
-          </p>
-        </div>
-        <div class="grid_12 omega feature">
+        <div class="grid_12 feature">
           <!-- <p><strong>1月上旬よりコーチの募集を開始予定です。</strong></p> -->
           <!-- <p><strong>コーチ募集中！</strong> Rails Girls Izumo では現在コーチを募集しています。
             <a href="(募集URL)" target="_blank">こちら</a>からお申し込み下さい。
@@ -186,319 +189,286 @@
           -->
         </div>
 
-        <hr />
+        <div class="grid_12 event-description" id="event-description">
+          <div class="grid_5 side venue">
+            <h3>インフォメーション</h3>
+            <div>
+              <strong>会場:</strong><br />
+              札幌市産業振興センター 1階 Sapporo Business HUB
+              <a href="https://maps.app.goo.gl/uy2x1XWtKuSY2yiD7">地図</a>
+              <br />北海道札幌市白石区東札幌5条1丁目1-1
+              <!-- TODO：以下のspanタグに駐車場の情報などを記載する -->
+              <!-- <span style="font-size: 0.8em"></span> -->
+            </div>
+          </div>
 
-        <!--  Update the texts! -->
-        <div class="grid_6 alpha">
-          <h2>10月17日 金曜日</h2>
-          <table id="schedule">
-            <tbody>
-              <tr>
-                <th>18:30 - 21:30</th>
-                <td>
-                  <h4>インストール・デイ</h4>
+          <div class="schedule grid_6" id="event-schedule">
+          <!--  Update the texts! -->
+            <div class="day-schedule">
+              <h2>10月17日 金曜日</h2>
+              <div class="plan">
+                <div class="plan-time">18:30 - 21:30</div>
+                <h4 class="plan-overview">インストール・デイ</h4>
+                <div class="plan-descripion">
                   まずは、参加者同士、お互いに知り合いになりましょう。ご自分のノートパソコンをお持ちください。
                   それぞれのパソコンにRubyとRailsをインストールし、Rubyプログラミングの最初の一歩をコーチとともに始めてみましょう。
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                </div>
+              </div>
+            </div>
 
-          <hr />
-
-          <h2>10月18日 土曜日</h2>
-          <!-- TODO：当日スケジュールの確認 -->
-          <table id="schedule">
-            <tbody>
-              <tr>
-                <th>9:00 - 10:00</th>
-                <td>
-                  <h4>レジストレーション、コーヒー</h4>
-                  金曜日にRuby on
-                  Railsのインストールトラブルがあれば、朝のうちに解決しておきましょう。
+            <div class="day-schedule">
+              <h2>10月18日 土曜日</h2>
+              <!-- TODO：当日スケジュールの確認 -->
+              <div class="plan">
+                <div class="plan-time">9:00 - 10:00</div>
+                <h4 class="plan-overview">レジストレーション、コーヒー</h4>
+                <div class="plan-descripion">
+                  金曜日にRuby on Railsのインストールトラブルがあれば、朝のうちに解決しておきましょう。
                   金曜日にすべてうまく行ったひとは参加しなくてもOKです。9:30ごろからのんびりきてください。
-                </td>
-              </tr>
+                </div>
+              </div>
 
-              <tr>
-                <th>10:00 - 10:30</th>
-                <td>
-                  <h4>開会</h4>
+              <div class="plan">
+                <div class="plan-time">10:00 - 10:30</div>
+                <h4 class="plan-overview">開会</h4>
+                <div class="plan-descripion">
                   一日の流れの説明。オーガナイザーから一言。
-                </td>
-              </tr>
+                </div>
+              </div>
 
-              <tr>
-                <th>10:30 - 11:00</th>
-                <td>
-                  <h4>自己紹介</h4>
+              <div class="plan">
+                <div class="plan-time">10:30 - 11:00</div>
+                <h4 class="plan-overview">自己紹介</h4>
+                <div class="plan-descripion">
                   一緒のチームのみんなに自己紹介しましょう!
-                </td>
-              </tr>
+                </div>
+              </div>
 
-              <tr>
-                <th>11:00 - 13:00</th>
-                <td>
-                  <h4>ワークショップ　ー　ウェブアプリの構築</h4>
+              <div class="plan">
+                <div class="plan-time">11:00 - 13:00</div>
+                <h4 class="plan-overview">ワークショップ　ー　ウェブアプリの構築</h4>
+                <div class="plan-descripion">
                   はじめてのウェブアプリにトライしてみよう！
-                </td>
-              </tr>
+                </div>
+              </div>
 
-              <tr>
-                <th>13:00 - 13:50</th>
-                <td>
-                  <h4>ランチ & スポンサーLT</h4>
-                </td>
-              </tr>
+              <div class="plan">
+                <div class="plan-time">13:00 - 13:50</div>
+                <h4 class="plan-overview">ランチ & スポンサーLT</h4>
+              </div>
 
-              <tr>
-                <th>13:50 - 15:10</th>
-                <td>
-                  <h4>ワークショップ　ー　ウェブアプリの構築</h4>
-                </td>
-              </tr>
+              <div class="plan">
+                <div class="plan-time">13:50 - 15:10</div>
+                <h4 class="plan-overview">ワークショップ　ー　ウェブアプリの構築</h4>
+              </div>
 
-              <tr>
-                <th>15:10- 15:20</th>
-                <td>
-                  <h4>休憩</h4>
-                </td>
-              </tr>
+              <div class="plan">
+                <div class="plan-time">15:10- 15:20</div>
+                <h4 class="plan-overview">休憩</h4>
+              </div>
 
-              <tr>
-                <th>15:20 - 16:30</th>
-                <td>
-                  <h4>ワークショップ</h4>
+              <div class="plan">
+                <div class="plan-time">15:20 - 16:30</div>
+                <h4 class="plan-overview">ワークショップ</h4>
+                <div class="plan-descripion">
                   自分流のウェブアプリに変えてみよう！
-                </td>
-              </tr>
+                </div>
+              </div>
 
-              <tr>
-                <th>16:30 -</th>
-                <td>
-                  <h4>アフターパーティー & コーチLT</h4>
+              <div class="plan">
+                <div class="plan-time">16:30 -</div>
+                <h4 class="plan-overview">アフターパーティー & コーチLT</h4>
+                <div class="plan-descripion">
                   参加者、コーチ、スタッフによるパーティです。ワークショップで聞き損ねたことや
                   RubyやRailsのこと、ステップアップの方法など、コーチに気軽に質問してみましょう。<br />
-                </td>
-              </tr>
-            </tbody>
-          </table>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="grid_5 side faq">
+            <h3>FAQ</h3>
+            <p>
+              <strong>参加費はどのくらいかかりますか？</strong>
+              無料です。申し込むときにはわくわくした気持ちだけあればいいです。
+            </p>
+
+            <p>
+              <strong>どのような人が参加するのでしょうか？</strong>
+              コンピュータを使ったことがある女性ならだれでも参加できます。これまでに開催されたRails
+              Girlsイベントには様々な年齢の女性がやってきました。ご自分のノートパソコンをお持ちください。
+            </p>
+
+            <p>
+              <strong>ワークショップで利用するツールで費用が発生するものはありますか？</strong>
+              ありません。イベント開催中に利用する Heroku 等の利用代金等はすべて
+              Rails Girls Japan にて負担します。
+            </p>
+
+            <p>
+              <strong>男性も参加できますか？</strong>
+              参加できます。ただし、必ずウェブアプリを作りたがっている女性と一緒に参加してください。申し込み人数が多い場合はお断りすることがあります。
+            </p>
+
+            <p>
+              <strong>プログラミングの経験があります。手伝うことはできますか？</strong>
+              はい！ Rails Girls Sapporo ではコーチとしてお手伝いしてくださる方を募集する予定です。<br />
+              準備が整い次第このサイトやXなどでお知らせいたします。
+            </p>
+          </div>
         </div>
 
-        <!--  These also, just update :) -->
+        <div class="grid_12 partners">
+          <h2 class="partners-header">パートナー</h3>
+          <div class="partners-lead">
+            <!-- <p>
+              ご支援いただけるパートナーを募集しております。<br>
+              <a href="https://docs.google.com/forms/d/e/1FAIpQLSfP7uGEfU6mvteTNY2npoI8QNXoBIA_MRiCmbJSfoCzGT3NGA/viewform" target="_blank">こちらのフォーム</a>からお問合せください。
+            </p> -->
+            <p>
+              多数のご支援のお申し出をいただき、ありがとうございました！<br />
+              Rails Girls Sapporo 2nd
+              は以下のすばらしいパートナーとの共同開催です。
+            </p>
+          </div>
+          
+          <div class="grid_12">
+            <!-- TODO:札幌市の共催、特別協力、後援のロゴを入れる -->
+            <div class="partner">
+              <div class="partner-logo">
+                <!-- <a href="#"><img src="" alt="一般財団法人さっぽろ産業振興財団"></a> -->
+              </div>
+              <div class="partner-description">
+                共催：一般財団法人さっぽろ産業振興財団
+              </div>
+            </div>
 
-        <div class="grid_5 push_1 omega side">
-          <h3>インフォメーション</h3>
-          <p>
-            <strong>会場:</strong><br />
-            札幌市産業振興センター 1階 Sapporo Business HUB<a
-              href="https://maps.app.goo.gl/uy2x1XWtKuSY2yiD7"
-              >地図</a
-            >
-            <br />北海道札幌市白石区東札幌5条1丁目1-1<br />
-            <!-- TODO：以下のspanタグに駐車場の情報などを記載する -->
-            <!-- <span style="font-size: 0.8em"></span> -->
-          </p>
+            <div class="partner">
+              <div class="partner-logo">
+                <!-- <a href="#"><img src="" alt="Sapporo Engineer Base"></a> -->
+              </div>
+              <div class="partner-description">
+                特別協力：Sapporo Engineer Base
+              </div>
+            </div>
 
-          <!-- Feel free to group the sponsors ascommi you wish. E.g media, friends, premium sponsors etc. You know best the situation in your city! Pictures should be either 100 x 100px or 250 x 90px -->
+            <div class="partner">
+              <!-- <div class="partner-logo">
+                <a href="#"><img src="" alt="札幌市"></a>
+              </div>
+              <div class="partner-description">
+                後援：札幌市
+              </div> -->
+            </div>
+          </div>
 
-          <h3>パートナー</h3>
+          <div class="partner">
+            <div class="partner-logo">
+              <a href="https://www.enishi-tech.com"><img src="https://railsgirls.jp/images/sponsors/enishi-tech.png" alt="株式会社えにしテック"></a>
+            </div>
+            <div class="partner-description">
+              <a href="https://www.enishi-tech.com">株式会社えにしテック</a>は、ソフトウェア開発、コンサルティング、教育の3つの領域でサービスを提供するテック企業です。「ひと、プロセス、プロダクトをいきいきと」をビジョンに、お客様がデジタルビジネスを継続的に進化していけるよう支援を行っています。
+            </div>
+          </div>
 
-          <!-- <p>
-            ご支援いただけるパートナーを募集しております。<br>
-            <a href="https://docs.google.com/forms/d/e/1FAIpQLSfP7uGEfU6mvteTNY2npoI8QNXoBIA_MRiCmbJSfoCzGT3NGA/viewform" target="_blank">こちらのフォーム</a>からお問合せください。
-          </p> -->
+          <div class="partner">
+            <div class="partner-logo">
+              <a href="https://www.tokyodev.com/"><img src="images/japan/tokyodev_logo_horizontal_black_high_res.png" alt="TokyoDev"></a>
+            </div>
+            <div class="partner-description">
+              <a href="https://www.tokyodev.com/">TokyoDev株式会社</a>は、オンライン求人掲示板やグローバルなメンバーが集うコミュニティを通じて、国内外に住むソフトウェア開発者の日本でのキャリアスタート・キャリアアップをサポートしています。
+            </div>
+          </div>
 
-          <p>
-            多数のご支援のお申し出をいただき、ありがとうございました！<br />
-            Rails Girls Sapporo 2nd
-            は以下のすばらしいパートナーとの共同開催です。
-          </p>
+          <div class="partner">
+            <div class="partner-logo">
+              <a href="https://www.pixiv.co.jp/"><img src="images/japan/pixiv.png" alt="ピクシブ株式会社"></a>
+            </div>
+            <div class="partner-description">
+              <a href="https://www.pixiv.co.jp/">ピクシブ株式会社</a>は、世の中のクリエイターの方々に対して「創作活動やファンとのコミュニケーションを楽しんでもらいたい」「創作活動を支え、創作文化を刺激していきたい」、そんな想いで、世界中の人々の創作活動を支える事業を展開しています。
+            </div>
+          </div>
 
-          <!-- TODO:札幌市の共催、特別協力、後援のロゴを入れる -->
-          <p>
-            <!-- <a href="" style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img src="" alt="一般財団法人さっぽろ産業振興財団" width="250"
-            /></a> -->
-            <br />共催：一般財団法人さっぽろ産業振興財団<br />
-          </p>
-          <p>
-            <!-- <a href="" style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img src="" alt="Sapporo Engineer Base" width="250"
-            /></a> -->
-            <br />特別協力：Sapporo Engineer Base<br />
-          </p>
-          <p>
-            <!-- <a href="" style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img src="" alt="札幌市" width="250"
-            /></a> -->
-            <!-- <br />後援：札幌市<br /> -->
-          </p>
-          <br />
-          <p>
-            <a
-              href="https://www.enishi-tech.com"
-              style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img
-                src="https://railsgirls.jp/images/sponsors/enishi-tech.png"
-                alt="株式会社えにしテック"
-                width="200"
-            /></a>
-            <a href="https://www.enishi-tech.com">株式会社えにしテック</a
-            >は、ソフトウェア開発、コンサルティング、教育の3つの領域でサービスを提供するテック企業です。「ひと、プロセス、プロダクトをいきいきと」をビジョンに、お客様がデジタルビジネスを継続的に進化していけるよう支援を行っています。
-          </p>
+          <div class="partner">
+            <div class="partner-logo">
+              <a href="https://careers.bm-sms.co.jp/engineer"><img src="images/japan/SMS.png" alt="株式会社エス・エム・エス"></a>
+            </div>
+            <div class="partner-description">
+              <a href="https://careers.bm-sms.co.jp/engineer">株式会社エス・エム・エス</a>は「高齢社会に適した情報インフラを構築することで人々の生活の質を向上し、社会に貢献し続ける」ことをミッションに掲げ、「高齢社会×情報」を切り口に40以上のサービスを展開しています。
+              高齢社会に求められる領域を医療・介護・ヘルスケア・シニアライフと捉え、高齢社会で働く方や事業者の方、高齢者ご自身やそのご家族がイキイキと生活できるサポートを提供することで豊かな社会の実現を目指しています。
+            </div>
+          </div>
 
-          <p>
-            <a
-              href="https://www.tokyodev.com/"
-              style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img
-                src="images/japan/tokyodev_logo_horizontal_black_high_res.png"
-                alt="TokyoDev"
-                width="200"
-            /></a>
-            <a href="https://www.tokyodev.com/">TokyoDev株式会社</a>
-            は、オンライン求人掲示板やグローバルなメンバーが集うコミュニティを通じて、国内外に住むソフトウェア開発者の日本でのキャリアスタート・キャリアアップをサポートしています。
-          </p>
-          <p>
-            <a
-              href="https://www.pixiv.co.jp/"
-              style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img
-                src="images/japan/pixiv.png"
-                alt="ピクシブ株式会社"
-                width="200"
-            /></a>
-            <a href="https://www.pixiv.co.jp/">ピクシブ株式会社</a>
-            は、世の中のクリエイターの方々に対して「創作活動やファンとのコミュニケーションを楽しんでもらいたい」「創作活動を支え、創作文化を刺激していきたい」、そんな想いで、世界中の人々の創作活動を支える事業を展開しています。
-          </p>
+          <div class="partner">
+            <div class="partner-logo">
+              <a href="https://jobs.st.inc/engineer"><img src="images/japan/STORES.png" alt="STORES株式会社"></a>
+            </div>
+            <div class="partner-description">
+              <a href="https://jobs.st.inc/engineer">STORES株式会社</a>は、「Just for Fun」をミッションに、こだわりや情熱、たのしみによって駆動される経済の発展に寄与することを目指しています。
+              個人事業者から中規模企業まで店舗を運営する方々にむけて、ネットショップ開設・POSレジ・キャッシュレス決済・オンライン予約システム・店舗アプリ作成など、お店のデジタル化を総合的に支援するサービスを展開しています。
+            </div>
+          </div>
 
-          <p>
-            <a
-              href="https://careers.bm-sms.co.jp/engineer"
-              style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img
-                src="images/japan/SMS.png"
-                alt="株式会社エス・エム・エス"
-                width="200"
-            /></a>
-            <a href="https://careers.bm-sms.co.jp/engineer">
-              株式会社エス・エム・エス</a
-            >
-            は「高齢社会に適した情報インフラを構築することで人々の生活の質を向上し、社会に貢献し続ける」ことをミッションに掲げ、「高齢社会×情報」を切り口に40以上のサービスを展開しています。
-            高齢社会に求められる領域を医療・介護・ヘルスケア・シニアライフと捉え、高齢社会で働く方や事業者の方、高齢者ご自身やそのご家族がイキイキと生活できるサポートを提供することで豊かな社会の実現を目指しています。
-          </p>
-          <p>
-            <a
-              href="https://jobs.st.inc/engineer"
-              style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img
-                src="images/japan/STORES.png"
-                alt="STORES株式会社"
-                width="200"
-            /></a>
-            <a href="https://jobs.st.inc/engineer">STORES株式会社</a>
-            は、「Just for
-            Fun」をミッションに、こだわりや情熱、たのしみによって駆動される経済の発展に寄与することを目指しています。
-            個人事業者から中規模企業まで店舗を運営する方々にむけて、ネットショップ開設・POSレジ・キャッシュレス決済・オンライン予約システム・店舗アプリ作成など、お店のデジタル化を総合的に支援するサービスを展開しています。
-          </p>
+          <div class="partner">
+            <div class="partner-logo">
+              <a href="https://bootcamp.fjord.jp"><img src="images/japan/FjordBootCamp_RGB.png" alt="フィヨルドブートキャンプ"></a>
+            </div>
+            <div class="partner-description">
+              <a href="https://bootcamp.fjord.jp">フィヨルドブートキャンプ</a>は、未経験からでも現場の即戦力になれるプログラミングスクールです。
+              現役エンジニアや技術コミュニティで実績のあるメンターの指導のもと、プログラマーを目指すカリキュラムに取り組めます。開発現場と同じ進め方で取り組むチーム開発や、ポートフォリオとなるWebアプリ制作を通じて、業界で求められる力を磨けます。受講生・卒業生・現役プログラマーが交流し、学び続けられるコミュニティの場も提供しています。
+            </div>
+          </div>
 
-          <p>
-            <a
-              href="https://bootcamp.fjord.jp"
-              style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img
-                src="images/japan/FjordBootCamp_RGB.png"
-                alt="フィヨルドブートキャンプ"
-                width="200"
-            /></a>
-            <a href="https://bootcamp.fjord.jp">フィヨルドブートキャンプ</a>
-            は、未経験からでも現場の即戦力になれるプログラミングスクールです。現役エンジニアや技術コミュニティで実績のあるメンターの指導のもと、プログラマーを目指すカリキュラムに取り組めます。開発現場と同じ進め方で取り組むチーム開発や、ポートフォリオとなるWebアプリ制作を通じて、業界で求められる力を磨けます。受講生・卒業生・現役プログラマーが交流し、学び続けられるコミュニティの場も提供しています。
-          </p>
+          <div class="partner">
+            <div class="partner-logo">
+              <a href="https://hello-world.smarthr.co.jp/"><img src="images/smarthr_200x40.png" alt="SmartHR"></a>
+            </div>
+            <div class="partner-description">
+              <a href="https://hello-world.smarthr.co.jp/">SmartHR</a>は、人事・労務の業務効率化と、データ活用によるタレントマネジメントや組織のパフォーマンス向上を実現するクラウド人事労務ソフトです。
+              労働にまつわる社会課題をなくし、誰もがその人らしく働ける社会の実現を目指し、働くすべての人の生産性向上を後押しします。私たちは、歴史に残る模範的なソフトウェアをつくる仲間を探しています。フルリモート勤務可能！
+            </div>
+          </div>
 
-          <p>
-            <a
-              href="https://hello-world.smarthr.co.jp/"
-              style="float: right; margin: 0 0 0 15px; border: 0"
-              ><img src="images/smarthr_200x40.png" alt="SmartHR" width="200"
-            /></a>
-            <a href="https://hello-world.smarthr.co.jp/">SmartHR</a
-            >は、人事・労務の業務効率化と、データ活用によるタレントマネジメントや組織のパフォーマンス向上を実現するクラウド人事労務ソフトです。労働に
-            まつわる社会課題をなくし、誰もがその人らしく働ける社会の実現を目指し、働くすべての人の生産性向上を後押しします。私たちは、歴史に残る模範的なソフトウェアをつくる仲間を探しています。フルリモート勤務可能！
-          </p>
-
-          <p>
-            <a href="http://ruby-no-kai.org">日本Rubyの会</a>
-            は、Rubyの利用者の支援とRuby(とRubyのライブラリ)開発者の支援を目的とした一般社団法人です。現在は、ドキュメントの整備や、イベントへの参加協力等を中心に活動しています。
-          </p>
-
-          <hr />
-
-          <h3>FAQ</h3>
-          <p>
-            <strong>参加費はどのくらいかかりますか？</strong>
-            無料です。申し込むときにはわくわくした気持ちだけあればいいです。
-          </p>
-
-          <p>
-            <strong>どのような人が参加するのでしょうか？</strong>
-            コンピュータを使ったことがある女性ならだれでも参加できます。これまでに開催されたRails
-            Girlsイベントには様々な年齢の女性がやってきました。ご自分のノートパソコンをお持ちください。
-          </p>
-
-          <p>
-            <strong
-              >ワークショップで利用するツールで費用が発生するものはありますか？</strong
-            >
-            ありません。イベント開催中に利用する Heroku 等の利用代金等はすべて
-            Rails Girls Japan にて負担します。
-          </p>
-
-          <p>
-            <strong>男性も参加できますか？</strong>
-            参加できます。ただし、必ずウェブアプリを作りたがっている女性と一緒に参加してください。申し込み人数が多い場合はお断りすることがあります。
-          </p>
-
-          <p>
-            <strong
-              >プログラミングの経験があります。手伝うことはできますか？</strong
-            >
-            はい！Rails Girls Sapporo
-            ではコーチとしてお手伝いしてくださる方を募集する予定です。<br />
-            準備が整い次第このサイトやXなどでお知らせいたします。
-          </p>
+          <div class="partner">
+            <div class="partner-logo">
+              <a href="http://ruby-no-kai.org"><img src="images/ruby-no-kai-long.png" alt="Nihon-Ruby-No-Kai" width="160"></a>
+            </div>
+            <div class="partner-description">
+              <a href="http://ruby-no-kai.org">日本Rubyの会</a>
+              は、Rubyの利用者の支援とRuby(とRubyのライブラリ)開発者の支援を目的とした一般社団法人です。現在は、ドキュメントの整備や、イベントへの参加協力等を中心に活動しています。
+            </div>
+          </div>
+          <div class="partner">
+            <!-- レイアウト用の空div -->
+          </div>
         </div>
 
-        <hr />
-        <!--  Update the team list       -->
-        <div class="coaches">
+        <div class="grid_12 coaches">
           <h2>Sapporo team</h2>
 
-          <a href="https://x.com/lemonade_37" class="grid_3" target="_blank">
-            <img
-              src="./images/sapporo-2nd/IMG_20190511_134739_789_2.jpg"
-              class="coach"
-            />
-            はる<br />Organizer<small>@lemonade_37</small>
-          </a>
-          <a href="https://x.com/025cm" class="grid_3" target="_blank">
-            <img
-              src="./images/sapporo-2nd/ebi_icon.jpg"
-              class="coach"
-            />
-            えび<br />Organizer<small>@025cm</small>
-          </a>
-          <a href="https://x.com/nringoame_" class="grid_3" target="_blank">
-            <img
-              src="./images/sapporo-2nd/カメラねこさん.jpg"
-              class="coach"
-            />
-            りんごあめ<br />Organizer<small>@nringoame_</small>
-          </a>
+          <div class="grid_3">
+            <a href="https://x.com/lemonade_37">
+              <img src="./images/sapporo-2nd/IMG_20190511_134739_789_2.jpg" class="coach-icon" />
+              はる<br/>Organizer<small>@lemonade_37</small>
+            </a>
+          </div>
+
+          <div class="grid_3">
+            <a href="https://x.com/025cm">
+              <img src="./images/sapporo-2nd/ebi_icon.jpg" class="coach-icon" />
+              えび<br/>Organizer<small>@025cm</small>
+            </a>
+          </div>
+
+          <div class="grid_3">
+            <a href="https://x.com/nringoame_">
+              <img src="./images/sapporo-2nd/カメラねこさん.jpg" class="coach-icon" />
+              りんごあめ<br/>Organizer<small>@nringoame_</small>
+            </a>
+          </div>
         </div>
       </div>
     </div>
-
     <!-- /content -->
 
     <footer>


### PR DESCRIPTION
@rena1208 @emorima 

I attatched the mobile-friendly style for Sapporo 2nd event page, same as #2217 .
please notice if I had some mistakes of contents.

----

#2217 で実施した、日本語イベントページ向けのモバイル対応をSapporo 2ndのイベントページに組み込みました。

元のイベントページの内容をもとに作った認識ですが、内容に誤り等があれば修正しますのでご指摘ください。

<img height="1000px" alt="image" src="https://github.com/user-attachments/assets/ae1144d2-918c-44b1-b3de-88f04afaa51a" />
