### PR TITLE
Fix fukuoka 2019 url

### DIFF
--- a/events.html
+++ b/events.html
@@ -509,7 +509,7 @@
         </div>
       </a>
 
-      <a href="./fukuoka.html" class="event"
+      <a href="./fukuoka-2019.html" class="event"
         style="background: url(images/railsgirls-sq.png) 0px -70px / 100% no-repeat;">
         <div>
           <h3>Fukuoka, Japan</h3>

--- a/events/events.json
+++ b/events/events.json
@@ -382,7 +382,7 @@
       "startDate": "2019-11-01",
       "endDate": "2019-11-02",
       "imageUrl": "images/fukuoka/fukuoka2019-logo.jpg",
-      "eventUrl": "/fukuoka.html"
+      "eventUrl": "/fukuoka-2019.html"
     },
     {
       "location": "Curitiba, Brasil",

--- a/fukuoka-2019.html
+++ b/fukuoka-2019.html
@@ -16,7 +16,7 @@
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@railsgirls" />
-    <meta property="og:url" content="https://railsgirls.com/fukuoka" />
+    <meta property="og:url" content="https://railsgirls.com/fukuoka-2019.html" />
     <meta property="og:title" content="Rails Girls Fukuoka, 1st & 2nd November 2019" />
     <meta
       property="og:description"


### PR DESCRIPTION
I noticed that the URL specified for the redirect was likely outdated, so I updated it.
Please review.

---

遷移先に指定されていたURLがおそらく古いままだったので修正しました。 ご確認お願いします。

関連：https://github.com/railsgirls-jp/railsgirls.jp/pull/902